### PR TITLE
Stopping ROS1 part of the bridge on bridge shutdown

### DIFF
--- a/baxter_bridge/src/baxter_bridge.cpp
+++ b/baxter_bridge/src/baxter_bridge.cpp
@@ -72,4 +72,6 @@ int main(int argc, char** argv)
         Factory::createBridge(topic);
     }
   }
+  ros::shutdown();
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
I found out that the ROS1 part of the bridge didn't stopped when killing the bridge, so on _rosnode list_, the bridge was still here. Moreover, on my project where I make a list of all the running bridges I am looking for ros1 bridges, and so these half-alive nodes appeared in my list.

So I am suggesting to add these two little lines after the main loop to clean up the ROS1 nodes that could be here.